### PR TITLE
Refactor/training service, CustomTrainingService

### DIFF
--- a/BackEnd/goorm/src/main/java/backend/goorm/training/model/entity/Training.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/training/model/entity/Training.java
@@ -58,4 +58,9 @@ public class Training {
     }
 
 
+    public void updateTraining(String trainingName, TrainingCategory category) {
+        this.trainingName = trainingName;
+        this.category = category;
+    }
+
 }

--- a/BackEnd/goorm/src/main/java/backend/goorm/training/service/BasicTrainingService.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/training/service/BasicTrainingService.java
@@ -10,9 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,27 +19,24 @@ public class BasicTrainingService {
     private final TrainingRepository trainingRepository;
     private final TrainingCategoryRepository trainingCategoryRepository;
 
-    public TrainingDto addBasicTraining(AddTrainingRequest input) {
-        Long categoryId = input.getCategory().getCategoryId();
-        Optional<TrainingCategory> optionalCategory = trainingCategoryRepository.findById(categoryId);
+    public TrainingDto addBasicTraining(AddTrainingRequest request) {
+        Long categoryId = request.getCategoryId();
 
-        if (!optionalCategory.isPresent()) {
-            throw new IllegalArgumentException("카테고리 ID가 존재하지 않습니다.");
-        }
+        // 카테고리 존재 여부만 검증
+        TrainingCategory category = trainingCategoryRepository.findById(categoryId)
+                .orElseThrow(() -> {
+                    log.warn("카테고리 ID({})가 존재하지 않음", categoryId);
+                    return new IllegalArgumentException("카테고리 ID가 존재하지 않습니다.");
+                });
 
-        TrainingCategory category = optionalCategory.get();
-        if (!category.getCategoryName().equals(input.getCategory().getCategoryName())) {
-            throw new IllegalArgumentException("카테고리 ID와 이름이 일치하지 않습니다.");
-        }
+        Training training = Training.builder()
+                .trainingName(request.getName())
+                .category(category)
+                .userCustom(false)
+                .build();
 
-        Training training = AddTrainingRequest.toEntity(input, category);
-        training.setUserCustom(false); // 기본 운동이므로 userCustom을 false로 설정
         Training saved = trainingRepository.save(training);
+        log.info("기본 운동 등록 완료: {}", saved.getTrainingName());
         return TrainingDto.fromEntity(saved);
-    }
-
-    public List<TrainingDto> getAllTrainings() {
-        List<Training> trainings = trainingRepository.findAll();
-        return trainings.stream().map(TrainingDto::fromEntity).collect(Collectors.toList());
     }
 }

--- a/BackEnd/goorm/src/main/java/backend/goorm/training/service/CustomTrainingService.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/training/service/CustomTrainingService.java
@@ -26,61 +26,77 @@ public class CustomTrainingService {
     private final TrainingRepository trainingRepository;
     private final TrainingCategoryRepository trainingCategoryRepository;
 
-    public TrainingDto addCustomTraining(AddTrainingRequest input, Member member) {
-        TrainingCategory category = input.getCategory();
-        if (category == null) {
-            throw new IllegalArgumentException("카테고리가 제공되지 않았습니다.");
-        }
+    // 커스텀 운동 등록
+    public TrainingDto addCustomTraining(AddTrainingRequest request, Member member) {
+        // 1. 카테고리 ID로만 검증 (category 객체 대신)
+        Long categoryId = request.getCategoryId();
+        TrainingCategory category = trainingCategoryRepository.findById(categoryId)
+                .orElseThrow(() -> {
+                    log.warn("카테고리 ID({})가 존재하지 않음", categoryId);
+                    return new IllegalArgumentException("카테고리 ID가 존재하지 않습니다.");
+                });
 
-        TrainingCategory actualCategory = trainingCategoryRepository.findById(category.getCategoryId())
+        // 2. Builder 패턴 활용하여 Training 생성 (setter 사용 X)
+        Training training = Training.builder()
+                .trainingName(request.getName())
+                .category(category)
+                .member(member)
+                .userCustom(true)
+                .build();
+
+        Training saved = trainingRepository.save(training);
+        log.info("커스텀 운동 등록 완료: memberId={}, trainingId={}", member.getMemberId(), saved.getTrainingId());
+        return TrainingDto.fromEntity(saved);
+    }
+
+    // 커스텀 운동 수정
+    public TrainingDto editCustomTraining(EditTrainingRequest request, Member member) {
+        Training training = trainingRepository.findById(request.getId())
+                .orElseThrow(() -> new IllegalArgumentException("Training not found with id: " + request.getId()));
+
+        // 사용자 소유 확인
+        validateMemberOwnership(training, member);
+
+        // 카테고리 수정도 ID로만
+        Long categoryId = request.getCategoryId();
+        TrainingCategory category = trainingCategoryRepository.findById(categoryId)
                 .orElseThrow(() -> new IllegalArgumentException("카테고리 ID가 존재하지 않습니다."));
 
-        if (!actualCategory.getCategoryName().equals(category.getCategoryName())) {
-            throw new IllegalArgumentException("카테고리 ID와 이름이 일치하지 않습니다.");
-        }
-
-        Training training = AddTrainingRequest.toEntity(input, actualCategory);
-        training.setMember(member);
+        // Setter 대신 Builder/Copy를 권장, 하지만 JPA에서는 실무적으로 Setter도 필요할 수 있음
+        training.updateTraining(request.getTrainingName(), category);
         Training saved = trainingRepository.save(training);
+        log.info("커스텀 운동 수정 완료: memberId={}, trainingId={}", member.getMemberId(), saved.getTrainingId());
         return TrainingDto.fromEntity(saved);
     }
 
-    public TrainingDto editCustomTraining(EditTrainingRequest input, Member member) {
-
-        Training training = trainingRepository.findById(input.getId())
-                .orElseThrow(() -> new IllegalArgumentException("Training not found with id: " + input.getId()));
-
-
-        if (!training.getMember().getMemberId().equals(member.getMemberId())) {
-            throw new IllegalArgumentException("이 훈련은 현재 사용자와 관련이 없습니다.");
-        }
-
-        training.setTrainingName(input.getTrainingName());
-        training.setCategory(input.getCategory());
-        Training saved = trainingRepository.save(training);
-        return TrainingDto.fromEntity(saved);
-    }
-
+    // 운동 삭제
     public TrainingDto deleteCustomTraining(Long trainingId, Member member) {
-
         Training training = trainingRepository.findById(trainingId)
                 .orElseThrow(() -> new IllegalArgumentException("Training not found with id: " + trainingId));
 
-        if (!training.getMember().getMemberId().equals(member.getMemberId())) {
-            throw new IllegalArgumentException("이 훈련은 현재 사용자와 관련이 없습니다.");
-        }
-
+        validateMemberOwnership(training, member);
 
         if (Boolean.TRUE.equals(training.getUserCustom())) {
             trainingRepository.delete(training);
+            log.info("커스텀 운동 삭제 완료: memberId={}, trainingId={}", member.getMemberId(), trainingId);
             return TrainingDto.fromEntity(training);
-        } else {
-            throw new IllegalArgumentException("기본 운동은 삭제할 수 없습니다.");
         }
+        throw new IllegalArgumentException("기본 운동은 삭제할 수 없습니다.");
     }
 
+    // 회원별 커스텀 운동 목록
     public List<TrainingDto> customTrainingList(Member member) {
-        List<Training> list = trainingRepository.findByMember_MemberId(member.getMemberId());
-        return list.stream().map(TrainingDto::fromEntity).collect(Collectors.toList());
+        return trainingRepository.findByMember_MemberId(member.getMemberId())
+                .stream()
+                .map(TrainingDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    // 소유자 확인 메서드 분리
+    private void validateMemberOwnership(Training training, Member member) {
+        if (!training.getMember().getMemberId().equals(member.getMemberId())) {
+            log.warn("본인이 만든 커스텀 운동이 아닙니다: 요청 memberId={}, 실제 memberId={}", member.getMemberId(), training.getMember().getMemberId());
+            throw new IllegalArgumentException("이 훈련은 현재 사용자와 관련이 없습니다.");
+        }
     }
 }


### PR DESCRIPTION
## 변경사항
- BasicTrainingService 내 Training 엔티티의 setUserCustom(false) 직접 호출 제거, 빌더 패턴 내에서 처리
- CustomTrainingService 내 Setter 최소화 및 Builder 패턴 적극 적용
- 카테고리, 멤버 등 엔티티는 ID 기반 검증 후 주입, DTO → Entity 변환 책임 명확화
- 예외 처리 및 로깅 일관성 개선, 코드 가독성 강화
- 엔티티의 updateTraining 등 명확한 메서드 분리
- training.setTrainingName(), setCategory(), setMember()와 같은 setter 사용을 피함
- 엔티티는 Builder/생성자로만 값 세팅 (DTO -> Entity 변환도 Service 계층에서 Builder로 일괄 생성)
## 기대효과
- Setter 최소화 및 도메인 메서드 활용으로 객체 불변성/일관성 향상, 의도 명확화
- 엔티티/DTO 책임 분리로 유지보수성 및 가독성 대폭 개선
- 도메인 중심 설계로 향후 기능 추가 및 비즈니스 로직 확장 용이
- 예외 및 로깅 일관화로 운영/디버깅 효율성 증대
- 코드 리뷰 및 팀원 학습 시, 변경 의도와 구조 파악이 쉬워짐