### PR TITLE
refactor: BasicTrainingService에 getAllTrainings 메서드 추가 및 컨트롤러 연동

### DIFF
--- a/BackEnd/goorm/src/main/java/backend/goorm/training/controller/BasicTrainingController.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/training/controller/BasicTrainingController.java
@@ -18,13 +18,19 @@ public class BasicTrainingController {
 
     private final BasicTrainingService basicTrainingService;
 
-
+    /**
+     * 기본 운동 등록 API
+     */
     @PostMapping
     public ResponseEntity<TrainingDto> addBasicTraining(@RequestBody AddTrainingRequest input) {
+        log.info("기본 운동 등록 요청: {}", input);
         TrainingDto result = basicTrainingService.addBasicTraining(input);
         return ResponseEntity.ok(result);
     }
 
+    /**
+     * 전체 기본 운동 목록 조회 API
+     */
     @GetMapping
     public ResponseEntity<List<TrainingDto>> getAllTrainings() {
         List<TrainingDto> trainings = basicTrainingService.getAllTrainings();

--- a/BackEnd/goorm/src/main/java/backend/goorm/training/service/BasicTrainingService.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/training/service/BasicTrainingService.java
@@ -9,6 +9,10 @@ import backend.goorm.training.repository.TrainingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Slf4j
@@ -38,5 +42,12 @@ public class BasicTrainingService {
         Training saved = trainingRepository.save(training);
         log.info("기본 운동 등록 완료: {}", saved.getTrainingName());
         return TrainingDto.fromEntity(saved);
+    }
+    @Transactional(readOnly = true)
+    public List<TrainingDto> getAllTrainings() {
+        List<Training> trainings = trainingRepository.findAll();
+        return trainings.stream()
+                .map(TrainingDto::fromEntity)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 변경사항
- BasicTrainingService에 전체 기본 운동 목록 조회용 getAllTrainings() 메서드 추가
- BasicTrainingController에서 getAllTrainings() 호출 가능하도록 연동
- API 코드/서비스 계층 구조의 일관성 유지 및 기능 명확화

## 기대효과
- 컨트롤러와 서비스 계층의 명확한 계약(contract) 체결로 코드 안정성 향상
- 신규 API 확장/유지보수 시, 기능 위치와 역할을 명확히 파악 가능
- 코드 구조 표준화로 팀원/후임자 온보딩 및 리뷰 효율성 증가
- 향후 목록형 API 확장(필터, 검색 등) 시 재사용 및 변경 용이
