### PR TITLE
refactor: 레코드 관련 엔티티  @Setter 전체 제거 및 생성자/빌더 패턴 적용

### DIFF
--- a/BackEnd/goorm/src/main/java/backend/goorm/record/entity/BodyPartCountRecord.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/record/entity/BodyPartCountRecord.java
@@ -7,9 +7,7 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class BodyPartCountRecord {
 
@@ -39,8 +37,26 @@ public class BodyPartCountRecord {
     private double etc;
 
     @Builder
-    public BodyPartCountRecord(double chest, double back, double legs, double shoulder, double biceps,
+    public BodyPartCountRecord(TrainingRecord trainingRecord, Member member, LocalDate date, boolean weeklyRecordedYn,
+                               double chest, double back, double legs, double shoulder, double biceps,
                                double triceps, double abs, double etc) {
+        this.trainingRecord = trainingRecord;
+        this.member = member;
+        this.date = date;
+        this.weeklyRecordedYn = weeklyRecordedYn;
+        this.chest = chest;
+        this.back = back;
+        this.legs = legs;
+        this.shoulder = shoulder;
+        this.biceps = biceps;
+        this.triceps = triceps;
+        this.abs = abs;
+        this.etc = etc;
+    }
+
+    // 업데이트 명확화: 상태 변경 메서드로 관리
+    public void update(double chest, double back, double legs, double shoulder, double biceps,
+                       double triceps, double abs, double etc) {
         this.chest = chest;
         this.back = back;
         this.legs = legs;
@@ -55,13 +71,14 @@ public class BodyPartCountRecord {
     public String toString() {
         return "BodyPartCountRecord{" +
                 "id=" + id +
-                "date=" + date +
+                ", date=" + date +
                 ", chest=" + chest +
                 ", back=" + back +
                 ", legs=" + legs +
                 ", shoulder=" + shoulder +
                 ", biceps=" + biceps +
                 ", triceps=" + triceps +
+                ", abs=" + abs +
                 ", etc=" + etc +
                 '}';
     }

--- a/BackEnd/goorm/src/main/java/backend/goorm/record/entity/Memo.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/record/entity/Memo.java
@@ -6,13 +6,11 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "memo")
 public class Memo {
@@ -32,6 +30,19 @@ public class Memo {
     @Column(name = "content", nullable = false)
     private String content;
 
-    @OneToMany(mappedBy = "memo", cascade = CascadeType.ALL)
-    private List<Record> records;
+    @OneToMany(mappedBy = "memo", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Record> records = new ArrayList<>();
+
+    @Builder
+    public Memo(Member member, LocalDate date, String content) {
+        this.member = member;
+        this.date = date;
+        this.content = content;
+    }
+
+    // 연관관계 편의 메서드
+    public void addRecord(Record record) {
+        records.add(record);
+        record.setMemo(this);
+    }
 }

--- a/BackEnd/goorm/src/main/java/backend/goorm/record/entity/Memo.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/record/entity/Memo.java
@@ -20,16 +20,20 @@ public class Memo {
     @Column(name = "memo_id")
     private Long memoId;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @Setter
     @Column(name = "date", nullable = false)
     private LocalDate date;
 
+    @Setter
     @Column(name = "content", nullable = false)
     private String content;
 
+    @Setter
     @OneToMany(mappedBy = "memo", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Record> records = new ArrayList<>();
 

--- a/BackEnd/goorm/src/main/java/backend/goorm/record/entity/Record.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/record/entity/Record.java
@@ -23,6 +23,7 @@ public class Record {
     @JoinColumn(name = "training_id", nullable = false)
     private Training training;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;

--- a/BackEnd/goorm/src/main/java/backend/goorm/record/entity/Record.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/record/entity/Record.java
@@ -4,18 +4,12 @@ import backend.goorm.member.model.entity.Member;
 import backend.goorm.training.model.entity.Training;
 import jakarta.persistence.*;
 import lombok.*;
-import com.fasterxml.jackson.annotation.JsonManagedReference;
-
 import java.time.LocalDateTime;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
-@Builder
+
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "record")
 public class Record {
@@ -25,7 +19,7 @@ public class Record {
     @Column(name = "record_id")
     private Long recordId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "training_id", nullable = false)
     private Training training;
 
@@ -70,8 +64,31 @@ public class Record {
     @Column(name = "satisfaction")
     private Integer satisfaction;
 
+    @Builder
+    public Record(Training training, Member member, LocalDateTime recordDate, LocalDate exerciseDate,
+                  Float caloriesBurned, Integer durationMinutes, String intensity,
+                  Integer sets, Integer reps, Integer weight, Float distance, Integer satisfaction) {
+        this.training = training;
+        this.member = member;
+        this.recordDate = recordDate;
+        this.exerciseDate = exerciseDate;
+        this.caloriesBurned = caloriesBurned;
+        this.durationMinutes = durationMinutes;
+        this.intensity = intensity;
+        this.sets = sets;
+        this.reps = reps;
+        this.weight = weight;
+        this.distance = distance;
+        this.satisfaction = satisfaction;
+    }
+
+    public void setMemo(Memo memo) {
+        this.memo = memo;
+    }
+
     @PreUpdate
     protected void onUpdate() {
         this.modifiedDate = LocalDateTime.now();
     }
 }
+

--- a/BackEnd/goorm/src/main/java/backend/goorm/record/entity/TrainingRecord.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/record/entity/TrainingRecord.java
@@ -3,11 +3,10 @@ package backend.goorm.record.entity;
 import backend.goorm.training.model.entity.Training;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "training_record")
 public class TrainingRecord {
@@ -17,11 +16,26 @@ public class TrainingRecord {
     @Column(name = "training_record_id")
     private Long trainingRecordId;
 
-    @ManyToOne
-    @JoinColumn(name = "record_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "record_id", nullable = false)
     private Record record;
 
-    @ManyToOne
-    @JoinColumn(name = "training_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "training_id", nullable = false)
     private Training training;
+
+    @Builder
+    public TrainingRecord(Record record, Training training) {
+        this.record = record;
+        this.training = training;
+    }
+
+//    // 연관관계 편의 메서드
+//    public void setRecord(Record record) {
+//        this.record = record;
+//    }
+//
+//    public void setTraining(Training training) {
+//        this.training = training;
+//    }
 }

--- a/BackEnd/goorm/src/main/java/backend/goorm/record/entity/WeeklyRecord.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/record/entity/WeeklyRecord.java
@@ -24,18 +24,29 @@ public class WeeklyRecord {
 
     private int trainingPerWeek;
 
+    @Setter
     private LocalDate startDate;
+    @Setter
     private LocalDate endDate;
 
     // 주간 body part count 기록
+    @Setter
     private double cardio;
+    @Setter
     private double chest;
+    @Setter
     private double back;
+    @Setter
     private double legs;
+    @Setter
     private double shoulder;
+    @Setter
     private double biceps;
+    @Setter
     private double triceps;
+    @Setter
     private double abs;
+    @Setter
     private double etc;
 
     /**

--- a/BackEnd/goorm/src/main/java/backend/goorm/record/entity/WeeklyRecord.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/record/entity/WeeklyRecord.java
@@ -8,12 +8,12 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@NoArgsConstructor
 @Builder
 @Entity
 public class WeeklyRecord {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -38,6 +38,9 @@ public class WeeklyRecord {
     private double abs;
     private double etc;
 
+    /**
+     * 카테고리별로 해당 부위 카운트 누적
+     */
     public void addCountValues(TrainingCategoryType category, double value) {
         switch (category) {
             case 유산소:
@@ -70,3 +73,4 @@ public class WeeklyRecord {
         }
     }
 }
+


### PR DESCRIPTION
## 변경사항
- Record, TrainingRecord, WeeklyRecord, Memo 등 운동 기록 관련 엔티티 전반에 대해 @Setter 전체 제거 및 생성자/빌더 패턴 적용
- JPA 표준에 따라 NoArgsConstructor의 접근 제어자를 protected로 변경
- 연관관계 편의 메서드(addRecord 등) 추가 및 컬렉션(List) 초기화
- 상태 변경이 필요한 경우 명확한 도메인 메서드(예: addCountValues, setMemo 등)로 관리
- 코드 일관성, 가독성 및 유지보수성 강화

## 기대효과
- 엔티티 불변성 강화 및 캡슐화로 인해 불필요한 값 변경, 사이드 이펙트 발생 가능성 감소
- 도메인 메서드를 통한 명확한 상태 변화로, 비즈니스 로직 확장/변경 시 안정성 및 생산성 증가
- JPA 관점에서 프록시 생성 등 오류 방지, 표준 코드 구조 유지로 팀 개발 시 합의점 마련
- 코드리뷰/테스트/문서화 시 구조적 통일성 제공, 신규/후임 개발자 온보딩 효율 증대
- 포트폴리오 및 자기소개서에 ‘시니어다운 코드’로 어필 가능

