### PR TITLE
refactor: 다이어트 관련 엔티티(JPA) Setter 제거, 불변성/컬렉션 초기화/표준화 적용

### DIFF
--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/entity/Diet.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/entity/Diet.java
@@ -32,6 +32,7 @@ public class Diet {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memo_id")
     private DietMemo dietMemo;
@@ -85,5 +86,6 @@ public class Diet {
             this.totalGram = 0.0f;
         }
     }
+
 }
 

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/entity/Diet.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/entity/Diet.java
@@ -11,8 +11,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @Entity
@@ -37,22 +36,28 @@ public class Diet {
     @JoinColumn(name = "memo_id")
     private DietMemo dietMemo;
 
+    @Setter
     @Column(name = "quantity")
     private Float quantity;
 
+    @Setter
     @Column(name = "gram")
     private Float gram;
 
+    @Setter
     @Column(name = "total_calories")
     private Float totalCalories;
 
+    @Setter
     @Column(name = "total_gram")
     private Float totalGram;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     @Column(name = "meal_time", nullable = false)
     private MealTime mealTime;
 
+    @Setter
     @Column(name = "diet_date", nullable = false)
     private LocalDate dietDate;
 
@@ -60,17 +65,25 @@ public class Diet {
     @Column(name = "created_at", updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
-    // 총 칼로리를 계산하고 설정하는 메서드
+    /**
+     * 총 칼로리, 그램 계산 메서드 (null-safe)
+     */
     public void calculateTotalCaloriesAndGram() {
+        if (food == null) {
+            this.totalCalories = 0.0f;
+            this.totalGram = 0.0f;
+            return;
+        }
         if (gram != null && gram > 0) {
             this.totalCalories = food.getCalories() / food.getGram() * gram;
-            this.totalGram = gram;  // 사용자가 gram을 직접 입력한 경우
+            this.totalGram = gram;
         } else if (quantity != null && quantity > 0) {
             this.totalCalories = food.getCalories() * quantity;
-            this.totalGram = quantity * food.getGram();  // 사용자가 quantity를 입력한 경우
+            this.totalGram = quantity * food.getGram();
         } else {
             this.totalCalories = 0.0f;
             this.totalGram = 0.0f;
         }
     }
 }
+

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/entity/DietImages.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/entity/DietImages.java
@@ -3,11 +3,13 @@ package backend.goorm.diet.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
+import jakarta.persistence.*;
+import lombok.*;
+
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "diet_images")
 public class DietImages {
@@ -24,8 +26,5 @@ public class DietImages {
     @Column(name = "image_url")
     private String imageUrl;
 
-    public DietImages(Diet diet, String imageUrl) {
-        this.diet = diet;
-        this.imageUrl = imageUrl;
-    }
 }
+

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/entity/DietMemo.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/entity/DietMemo.java
@@ -2,15 +2,14 @@ package backend.goorm.diet.entity;
 
 import backend.goorm.member.model.entity.Member;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.ArrayList;
+
 
 @Getter
-@Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @Entity
@@ -27,8 +26,8 @@ public class DietMemo {
     private Member member;
 
     @OneToMany(mappedBy = "dietMemo", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Diet> diets;
-
+    @Builder.Default
+    private List<Diet> diets = new ArrayList<>();
 
     @Column(name = "date", nullable = false)
     private LocalDate date;
@@ -36,5 +35,10 @@ public class DietMemo {
     @Column(name = "content", columnDefinition = "TEXT")
     private String content;
 
-
+    // 도메인 메서드 (연관관계 관리)
+    public void addDiet(Diet diet) {
+        this.diets.add(diet);
+        diet.setDietMemo(this);
+    }
 }
+

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/entity/Food.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/entity/Food.java
@@ -3,15 +3,15 @@ package backend.goorm.diet.entity;
 import backend.goorm.member.model.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
-
 import java.util.List;
+import java.util.ArrayList;
+
 
 @Getter
-@Setter
-@Entity
-@Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Builder
+@Entity
 @Table(name = "food")
 public class Food {
 
@@ -47,14 +47,19 @@ public class Food {
     private Float saturatedFat;
     private Float transFat;
 
-
     @Column(name = "user_register", nullable = false)
     private Boolean userRegister = false;
-
 
     @Column(name = "use_count", nullable = false)
     private Integer useCount = 0;
 
     @OneToMany(mappedBy = "food")
-    private List<Diet> diets;
+    @Builder.Default
+    private List<Diet> diets = new ArrayList<>();
+
+    // 도메인 메서드: 사용 카운트 증가
+    public void increaseUseCount() {
+        this.useCount++;
+    }
+
 }


### PR DESCRIPTION
## 변경사항
- Diet, DietImages, DietMemo, Food 등 다이어트 관련 엔티티에서 @Setter 전체 제거 및 필요한 경우 도메인 메서드/부분 Setter만 허용
- @NoArgsConstructor(access = PROTECTED) 적용으로 JPA 표준화 및 외부 직접 생성 방지
- 컬렉션 필드(List) Builder.Default로 초기화하여 NPE 예방
- 상태 변경(카운트 증가 등)은 도메인 메서드로 분리하여 의도 명확화
- 빌더/생성자 패턴 적용으로 엔티티 불변성 강화

## 기대효과
- 엔티티 불변성/상태 신뢰성 향상, 예기치 않은 값 변경 및 런타임 오류/버그 위험 최소화
- 컬렉션 초기화로 인한 NullPointerException 방지 및 안정적 연관관계 관리
- JPA 관점에서 표준화된 코드 구조로 팀 내 코드리뷰, 유지보수, 신규 개발자 온보딩 효율성 증가
- 도메인 중심 설계로 비즈니스 로직 추가 및 확장에 용이
