### PR TITLE
refactor: Diet 도메인 DTO 전체 불변 객체 설계 및 Setter 제거, 코드 표준화

### DIFF
--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/DietCreateRequestDto.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/DietCreateRequestDto.java
@@ -9,7 +9,6 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Getter
-@Setter
 @ToString
 public class DietCreateRequestDto {
     private LocalDate dietDate;

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/DietMemoDto.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/DietMemoDto.java
@@ -3,26 +3,25 @@ package backend.goorm.diet.dto;
 import backend.goorm.diet.entity.DietMemo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
-@Data
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 public class DietMemoDto {
     private Long memoId;
-    private Long memberId; // Member 객체 대신 memberId만 포함
+    private Long memberId;
     private String content;
     private LocalDate date;
 
     public static DietMemoDto fromEntity(DietMemo memo) {
         return DietMemoDto.builder()
                 .memoId(memo.getMemoId())
-                .memberId(memo.getMember().getMemberId()) // Member 객체 대신 memberId만 설정
+                .memberId(memo.getMember().getMemberId())
                 .content(memo.getContent())
                 .date(memo.getDate())
                 .build();

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/DietResponseDto.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/DietResponseDto.java
@@ -1,6 +1,7 @@
 package backend.goorm.diet.dto;
 
 import backend.goorm.diet.entity.Diet;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +11,7 @@ import java.util.stream.Collectors;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class DietResponseDto {
     private Long dietId;
     private String mealTime;

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/DietUpdateRequestDto.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/DietUpdateRequestDto.java
@@ -1,11 +1,5 @@
 package backend.goorm.diet.dto;
-
-import backend.goorm.diet.entity.Diet;
-import backend.goorm.diet.entity.Food;
-import backend.goorm.diet.enums.MealTime;
-import backend.goorm.diet.repository.FoodRepository;
 import lombok.*;
-
 import java.time.LocalDate;
 import java.util.List;
 
@@ -13,7 +7,6 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Getter
-@Setter
 @ToString
 public class DietUpdateRequestDto {
     private Long dietId;
@@ -26,25 +19,11 @@ public class DietUpdateRequestDto {
     @AllArgsConstructor
     @Builder
     @Getter
-    @Setter
     @ToString
     public static class FoodQuantity {
         private Long foodId;
         private Float quantity;
         private Float gram;
-    }
-
-    public void updateEntity(Diet diet, FoodRepository foodRepository) {
-        diet.setDietDate(this.dietDate);
-        diet.setMealTime(MealTime.valueOf(this.mealTime.toUpperCase()));
-
-        if (this.foodQuantities != null && !this.foodQuantities.isEmpty()) {
-            // Food ID로 Food 객체를 데이터베이스에서 조회
-            Food food = foodRepository.findById(this.foodQuantities.get(0).getFoodId())
-                    .orElseThrow(() -> new IllegalArgumentException("Food not found with id: " + this.foodQuantities.get(0).getFoodId()));
-            diet.setFood(food);
-            diet.setQuantity(this.foodQuantities.get(0).getQuantity());
-        }
     }
 
 }

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/FoodResponseDto.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/FoodResponseDto.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/FoodUpdateRequestDto.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/FoodUpdateRequestDto.java
@@ -1,13 +1,15 @@
 package backend.goorm.diet.dto;
 
-import backend.goorm.diet.entity.Food;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class FoodUpdateRequestDto {
-
         private String foodName;
         private Float calories;
         private Float carbohydrate;
@@ -18,18 +20,5 @@ public class FoodUpdateRequestDto {
         private Float cholesterol;
         private Float saturatedFat;
         private Float transFat;
-
-        public void updateEntity(Food food) {
-
-                food.setFoodName(this.foodName);
-                food.setCalories(this.calories);
-                food.setCarbohydrate(this.carbohydrate);
-                food.setProtein(this.protein);
-                food.setFat(this.fat);
-                food.setSugar(this.sugar);
-                food.setSalt(this.salt);
-                food.setCholesterol(this.cholesterol);
-                food.setSaturatedFat(this.saturatedFat);
-                food.setTransFat(this.transFat);
-        }
 }
+

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/FoodUserDto.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/FoodUserDto.java
@@ -4,9 +4,8 @@ import backend.goorm.diet.entity.Food;
 import lombok.*;
 
 @Getter
-@Setter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class FoodUserDto {
     private String foodType;
@@ -21,12 +20,13 @@ public class FoodUserDto {
     private Float cholesterol;
     private Float saturatedFat;
     private Float transFat;
-    private String imageUrl; // 이미지 URL 필드 추가
-    private Integer useCount = 0; // 기본값 설정
+    private String imageUrl;
+    @Builder.Default
+    private Integer useCount = 0;
+    @Builder.Default
     private Boolean userRegister = true;
 
     public Food toEntity() {
-
         return Food.builder()
                 .foodName(this.foodName)
                 .gram(this.gram)
@@ -39,25 +39,8 @@ public class FoodUserDto {
                 .cholesterol(this.cholesterol)
                 .saturatedFat(this.saturatedFat)
                 .transFat(this.transFat)
-                .useCount(this.useCount) // 기본값 설정
-                .userRegister(this.userRegister) // 유저가 등록한 음식인지 여부 설정
+                .useCount(this.useCount)
+                .userRegister(this.userRegister)
                 .build();
-    }
-
-    public void updateEntity(Food food) {
-
-        food.setFoodName(this.foodName);
-        food.setGram(this.gram);
-        food.setCalories(this.calories);
-        food.setCarbohydrate(this.carbohydrate);
-        food.setProtein(this.protein);
-        food.setFat(this.fat);
-        food.setSugar(this.sugar);
-        food.setSalt(this.salt);
-        food.setCholesterol(this.cholesterol);
-        food.setSaturatedFat(this.saturatedFat);
-        food.setTransFat(this.transFat);
-        food.setUseCount(this.useCount); // 기본값 설정
-        food.setUserRegister(this.userRegister);
     }
 }

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/NutrientPercentage.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/dto/NutrientPercentage.java
@@ -1,18 +1,17 @@
 package backend.goorm.diet.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class NutrientPercentage {
     private double carbsPercentage;
     private double proteinPercentage;
     private double fatPercentage;
-    private double totalCalories;   // 추가
+    private double totalCalories;
 }
-

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/entity/Diet.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/entity/Diet.java
@@ -24,9 +24,11 @@ public class Diet {
     @Column(name = "diet_id")
     private Long dietId;
 
+    @Setter
     @ManyToOne
     @JoinColumn(name = "food_id")
     private Food food;
+
 
     @ManyToOne
     @JoinColumn(name = "member_id")

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/entity/Food.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/entity/Food.java
@@ -20,31 +20,47 @@ public class Food {
     @Column(name = "food_id")
     private Long foodId;
 
+    @Setter
     @Column(name = "food_name", nullable = false)
     private String foodName;
 
+    @Setter
     @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Setter
     private Float gram;
 
+    @Setter
     @Column(name = "calories")
     private Float calories;
 
+    @Setter
     @Column(name = "carbohydrate")
     private Float carbohydrate;
 
+    @Setter
     @Column(name = "protein")
     private Float protein;
 
+    @Setter
     @Column(name = "fat")
     private Float fat;
 
+    @Setter
     private Float sugar;
+
+    @Setter
     private Float salt;
+
+    @Setter
     private Float cholesterol;
+
+    @Setter
     private Float saturatedFat;
+
+    @Setter
     private Float transFat;
 
     @Column(name = "user_register", nullable = false)

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/service/DietService.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/service/DietService.java
@@ -70,6 +70,20 @@ public class DietService {
 
         return responses;
     }
+    public void updateDietEntity(Diet diet, DietUpdateRequestDto dto, FoodRepository foodRepository) {
+        diet.setDietDate(dto.getDietDate());
+        diet.setMealTime(MealTime.valueOf(dto.getMealTime().toUpperCase()));
+
+        if (dto.getFoodQuantities() != null && !dto.getFoodQuantities().isEmpty()) {
+            DietUpdateRequestDto.FoodQuantity fq = dto.getFoodQuantities().get(0);
+            Food food = foodRepository.findById(fq.getFoodId())
+                    .orElseThrow(() -> new IllegalArgumentException("Food not found with id: " + fq.getFoodId()));
+            diet.setFood(food);
+            diet.setQuantity(fq.getQuantity());
+        }
+        // memo 등 필요한 추가 변경도 여기서 처리
+    }
+
 
     @Transactional
     public List<DietResponseDto> editDietsAndMemos(List<DietUpdateRequestDto> requests, Member member) {

--- a/BackEnd/goorm/src/main/java/backend/goorm/diet/service/FoodService.java
+++ b/BackEnd/goorm/src/main/java/backend/goorm/diet/service/FoodService.java
@@ -69,6 +69,20 @@ public class FoodService {
         return FoodResponseDto.fromEntity(food);
     }
 
+    public void updateFoodEntity(Food food, FoodUpdateRequestDto dto) {
+        food.setFoodName(dto.getFoodName());
+        food.setCalories(dto.getCalories());
+        food.setCarbohydrate(dto.getCarbohydrate());
+        food.setProtein(dto.getProtein());
+        food.setFat(dto.getFat());
+        food.setSugar(dto.getSugar());
+        food.setSalt(dto.getSalt());
+        food.setCholesterol(dto.getCholesterol());
+        food.setSaturatedFat(dto.getSaturatedFat());
+        food.setTransFat(dto.getTransFat());
+    }
+
+
     public FoodResponseDto updateFood(Long memberId, Long foodId, FoodUpdateRequestDto dto) {
 
         Food food = foodRepository.findById(foodId)


### PR DESCRIPTION
## 변경사항
- Diet, Food, Memo 등 다이어트 도메인 DTO에서 @Setter 전체 제거, @Getter만 허용하는 불변 객체 패턴으로 통일
- @Builder, @AllArgsConstructor, @NoArgsConstructor 등 생성/직렬화/테스트 활용성을 높이도록 적용
- DTO 내 updateEntity 등 비즈니스 로직/엔티티 변경은 서비스 계층에서 처리하도록 분리
- 기본값 필요시 @Builder.Default로 선언, null-safe/생성자 기반 값 세팅 표준화
- 정적 팩토리/리스트 변환 메서드 등 유틸 패턴 통일 및 코드 가독성/일관성 강화

## 기대효과
- DTO 계층 데이터의 불변성 및 신뢰성 강화로 side-effect, 값 변이 위험 최소화
- 코드 표준화로 유지보수성, 가독성 및 코드리뷰/테스트 효율성 증가
- 계층 간 데이터 전달의 신뢰성/안정성 향상, 팀 내 온보딩 및 개발 효율성 개선